### PR TITLE
Handle onboarding redirect when user has no organization

### DIFF
--- a/src/auth/guard/index.ts
+++ b/src/auth/guard/index.ts
@@ -3,3 +3,5 @@ export * from './auth-guard';
 export * from './guest-guard';
 
 export * from './role-based-guard';
+
+export * from './onboarding-guard';

--- a/src/auth/guard/onboarding-guard.tsx
+++ b/src/auth/guard/onboarding-guard.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+
+import { paths } from 'src/routes/paths';
+import { useRouter, usePathname } from 'src/routes/hooks';
+
+import { SplashScreen } from 'src/components/loading-screen';
+
+import { useAuthContext } from '../hooks';
+
+// ----------------------------------------------------------------------
+
+export type OnboardingGuardProps = {
+  children: React.ReactNode;
+};
+
+export function OnboardingGuard({ children }: OnboardingGuardProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const { user, loading } = useAuthContext();
+
+  const [isChecking, setIsChecking] = useState<boolean>(true);
+
+  useEffect(() => {
+    if (loading) {
+      return;
+    }
+
+    // If user is logged in but has no organization, force onboarding
+    if (user && !user.current_organization_id) {
+      if (pathname !== paths.onboarding.root) {
+        router.replace(paths.onboarding.root);
+      } else {
+        setIsChecking(false);
+      }
+      return;
+    }
+
+    // If user has organization but tries to access onboarding, redirect to dashboard
+    if (user && user.current_organization_id && pathname.startsWith(paths.onboarding.root)) {
+      router.replace(paths.dashboard.root);
+      return;
+    }
+
+    setIsChecking(false);
+  }, [user, loading, pathname, router]);
+
+  if (isChecking) {
+    return <SplashScreen />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/routes/sections/dashboard.tsx
+++ b/src/routes/sections/dashboard.tsx
@@ -10,7 +10,7 @@ import { LoadingScreen } from 'src/components/loading-screen';
 
 import { AccountLayout } from 'src/sections/account/account-layout';
 
-import { AuthGuard } from 'src/auth/guard';
+import { AuthGuard, OnboardingGuard } from 'src/auth/guard';
 
 import { usePathname } from '../hooks';
 
@@ -120,7 +120,13 @@ const accountLayout = () => (
 export const dashboardRoutes: RouteObject[] = [
   {
     path: 'dashboard',
-    element: CONFIG.auth.skip ? dashboardLayout() : <AuthGuard>{dashboardLayout()}</AuthGuard>,
+    element: CONFIG.auth.skip
+      ? dashboardLayout()
+      : (
+          <AuthGuard>
+            <OnboardingGuard>{dashboardLayout()}</OnboardingGuard>
+          </AuthGuard>
+        ),
     children: [
       { index: true, element: <IndexPage /> },
       { path: 'ecommerce', element: <OverviewEcommercePage /> },

--- a/src/routes/sections/onboarding.tsx
+++ b/src/routes/sections/onboarding.tsx
@@ -7,6 +7,8 @@ import { OnboardingLayout } from 'src/layouts/onboarding';
 
 import { SplashScreen } from 'src/components/loading-screen';
 
+import { AuthGuard, OnboardingGuard } from 'src/auth/guard';
+
 const Onboarding = {
   OnboardingMultiSteps: lazy(() => import('src/pages/onboarding')),
 };
@@ -29,9 +31,13 @@ export const onboardingRoutes: RouteObject[] = [
   {
     path: 'onboarding',
     element: (
-      <Suspense fallback={<SplashScreen />}>
-        <Outlet />
-      </Suspense>
+      <AuthGuard>
+        <OnboardingGuard>
+          <Suspense fallback={<SplashScreen />}>
+            <Outlet />
+          </Suspense>
+        </OnboardingGuard>
+      </AuthGuard>
     ),
     children: [onboarding],
   },


### PR DESCRIPTION
## Summary
- enforce onboarding flow with new `OnboardingGuard`
- wrap dashboard routes with the guard
- protect onboarding route and ensure correct import order

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68425beb0dd4832baef9a20fd4b24e03