### PR TITLE
Add password reset API integration

### DIFF
--- a/src/auth/context/jwt/action.ts
+++ b/src/auth/context/jwt/action.ts
@@ -136,3 +136,66 @@ export const signOut = async (): Promise<void> => {
     throw error;
   }
 };
+
+/** **************************************
+ * Forgot password
+ *************************************** */
+export const forgotPassword = async (email: string): Promise<void> => {
+  try {
+    await getCsrfToken();
+
+    await axios.post('/api/auth/forgot-password', { email });
+  } catch (error: any) {
+    console.error('Erro ao solicitar redefinição de senha:', error);
+
+    if (error.response?.data?.error) {
+      throw new Error(error.response.data.error);
+    }
+
+    if (error.response?.data?.message) {
+      throw new Error(error.response.data.message);
+    }
+
+    throw error;
+  }
+};
+
+/** **************************************
+ * Reset password
+ *************************************** */
+export type ResetPasswordParams = {
+  email: string;
+  token: string;
+  password: string;
+  passwordConfirmation: string;
+};
+
+export const resetPassword = async ({
+  email,
+  token,
+  password,
+  passwordConfirmation,
+}: ResetPasswordParams): Promise<void> => {
+  try {
+    await getCsrfToken();
+
+    await axios.post('/api/auth/reset-password', {
+      email,
+      token,
+      password,
+      password_confirmation: passwordConfirmation,
+    });
+  } catch (error: any) {
+    console.error('Erro ao redefinir senha:', error);
+
+    if (error.response?.data?.error) {
+      throw new Error(error.response.data.error);
+    }
+
+    if (error.response?.data?.message) {
+      throw new Error(error.response.data.message);
+    }
+
+    throw error;
+  }
+};

--- a/src/auth/view/auth-demo/centered/centered-reset-password-view.tsx
+++ b/src/auth/view/auth-demo/centered/centered-reset-password-view.tsx
@@ -1,4 +1,5 @@
 import { z as zod } from 'zod';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
@@ -13,6 +14,7 @@ import { Form, Field } from 'src/components/hook-form';
 
 import { FormHead } from '../../../components/form-head';
 import { FormReturnLink } from '../../../components/form-return-link';
+import { forgotPassword } from '../../../context/jwt';
 
 // ----------------------------------------------------------------------
 
@@ -28,6 +30,9 @@ export const ResetPasswordSchema = zod.object({
 // ----------------------------------------------------------------------
 
 export function CenteredResetPasswordView() {
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState('');
+
   const defaultValues: ResetPasswordSchemaType = {
     email: '',
   };
@@ -44,10 +49,12 @@ export function CenteredResetPasswordView() {
 
   const onSubmit = handleSubmit(async (data) => {
     try {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      console.info('DATA', data);
-    } catch (error) {
-      console.error(error);
+      setError('');
+      await forgotPassword(data.email);
+      setSuccess(true);
+    } catch (err: any) {
+      console.error(err);
+      setError(err.message || 'Erro ao solicitar redefinição de senha.');
     }
   });
 
@@ -60,6 +67,40 @@ export function CenteredResetPasswordView() {
         autoFocus
         slotProps={{ inputLabel: { shrink: true } }}
       />
+
+      {error && (
+        <Box
+          sx={{
+            color: 'error.main',
+            textAlign: 'center',
+            mt: 1,
+            mb: 1,
+            p: 2,
+            bgcolor: 'error.lighter',
+            borderRadius: 1,
+            typography: 'body2',
+          }}
+        >
+          {error}
+        </Box>
+      )}
+
+      {success && (
+        <Box
+          sx={{
+            color: 'success.main',
+            textAlign: 'center',
+            mt: 1,
+            mb: 1,
+            p: 2,
+            bgcolor: 'success.lighter',
+            borderRadius: 1,
+            typography: 'body2',
+          }}
+        >
+          Verifique seu email e siga as instruções para redefinir a senha.
+        </Box>
+      )}
 
       <LoadingButton
         fullWidth


### PR DESCRIPTION
## Summary
- implement forgotPassword and resetPassword actions for JWT flow
- connect Reset Password form to POST `/api/auth/forgot-password`
- update Update Password form to consume token/email from query params and POST to `/api/auth/reset-password`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6843269abca4832b90ef82d84898e814