### PR TITLE
Remove OTP field from update password form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,9 @@
         "@fullcalendar/timeline": "^6.1.15",
         "@hookform/resolvers": "^3.9.1",
         "@iconify/react": "^5.1.0",
+        "@mui/icons-material": "^7.0.1",
         "@mui/lab": "^6.0.0-beta.21",
-        "@mui/material": "^6.3.0",
+        "@mui/material": "^6.4.9",
         "@mui/x-data-grid": "^7.23.5",
         "@mui/x-date-pickers": "^7.23.3",
         "@mui/x-tree-view": "^7.23.2",
@@ -47,6 +48,7 @@
         "@tiptap/pm": "^2.11.0",
         "@tiptap/react": "^2.11.0",
         "@tiptap/starter-kit": "^2.11.0",
+        "@types/react-input-mask": "^3.0.6",
         "apexcharts": "^4.3.0",
         "autosuggest-highlight": "^3.3.4",
         "aws-amplify": "^6.11.0",
@@ -76,6 +78,7 @@
         "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.54.2",
         "react-i18next": "^15.4.0",
+        "react-input-mask": "^2.0.4",
         "react-joyride": "^2.9.3",
         "react-map-gl": "^7.1.8",
         "react-markdown": "^9.0.1",
@@ -120,7 +123,8 @@
         "vite-plugin-checker": "^0.8.0"
       },
       "engines": {
-        "node": "20.x"
+        "node": ">=14.0.0",
+        "pnpm": ">=7.0.0"
       },
       "peerDependencies": {
         "@types/mapbox-gl": "3.1.0"
@@ -1525,13 +1529,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3498,13 +3499,39 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.3.0.tgz",
-      "integrity": "sha512-/d8NwSuC3rMwCjswmGB3oXC4sdDuhIUJ8inVQAxGrADJhf0eq/kmy+foFKvpYhHl2siOZR+MLdFttw6/Bzqtqg==",
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.12.tgz",
+      "integrity": "sha512-M7IkG4LqSJfkY+thlQQHNkcS5NdmMDwLq/2RKoW40XR0mv/2BYb6X8fRnyaxP4zGdPD2M4MQdbzKihSVormJ7Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.1.1.tgz",
+      "integrity": "sha512-X37+Yc8QpEnl0sYmz+WcLFy2dWgNRzbswDzLPXG7QU1XDVlP5TPp1HXjdmCupOWLL/I9m1fyhcyZl8/HPpp/Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.1.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/lab": {
@@ -3553,16 +3580,16 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.3.0.tgz",
-      "integrity": "sha512-qhlTFyRMxfoVPxUtA5e8IvqxP0dWo2Ij7cvot7Orag+etUlZH+3UwD8gZGt+3irOoy7Ms3UNBflYjwEikUXtAQ==",
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.12.tgz",
+      "integrity": "sha512-VqoLNS5UaNqoS1FybezZR/PaAvzbTmRe0Mx//afXbolIah43eozpX2FckaFffLvMoiSIyxx1+AMHyENTr2Es0Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.3.0",
-        "@mui/system": "^6.3.0",
-        "@mui/types": "^7.2.20",
-        "@mui/utils": "^6.3.0",
+        "@mui/core-downloads-tracker": "^6.4.12",
+        "@mui/system": "^6.4.12",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -3581,7 +3608,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.3.0",
+        "@mui/material-pigment-css": "^6.4.12",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3602,13 +3629,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.3.0.tgz",
-      "integrity": "sha512-tdS8jvqMokltNTXg6ioRCCbVdDmZUJZa/T9VtTnX2Lwww3FTgCakst9tWLZSxm1fEE9Xp0m7onZJmgeUmWQYVw==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
+      "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.3.0",
+        "@mui/utils": "^6.4.9",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3629,9 +3656,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.3.0.tgz",
-      "integrity": "sha512-iWA6eyiPkO07AlHxRUvI7dwVRSc+84zV54kLmjUms67GJeOWVuXlu8ZO+UhCnwJxHacghxnabsMEqet5PYQmHg==",
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.11.tgz",
+      "integrity": "sha512-74AUmlHXaGNbyUqdK/+NwDJOZqgRQw6BcNvhoWYLq3LGbLTkE+khaJ7soz6cIabE4CPYqO2/QAIU1Z/HEjjpcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -3663,16 +3690,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.3.0.tgz",
-      "integrity": "sha512-L+8hUHMNlfReKSqcnVslFrVhoNfz/jw7Fe9NfDE85R3KarvZ4O3MU9daF/lZeqEAvnYxEilkkTfDwQ7qCgJdFg==",
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.12.tgz",
+      "integrity": "sha512-fgEfm1qxpKCztndESeL1L0sLwA2c7josZ2w42D8OM3pbLee4bH2twEjoMo6qf7z2rNw1Uc9EU9haXeMoq0oTdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.3.0",
-        "@mui/styled-engine": "^6.3.0",
-        "@mui/types": "^7.2.20",
-        "@mui/utils": "^6.3.0",
+        "@mui/private-theming": "^6.4.9",
+        "@mui/styled-engine": "^6.4.11",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3703,9 +3730,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.20",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.20.tgz",
-      "integrity": "sha512-straFHD7L8v05l/N5vcWk+y7eL9JF0C2mtph/y4BPm3gn2Eh61dDwDB65pa8DLss3WJfDXYC7Kx5yjP0EmXpgw==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3717,13 +3744,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.3.0.tgz",
-      "integrity": "sha512-MkDBF08OPVwXhAjedyMykRojgvmf0y/jxkBWjystpfI/pasyTYrfdv4jic6s7j3y2+a+SJzS9qrD6X8ZYj/8AQ==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
+      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.20",
+        "@mui/types": "~7.2.24",
         "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -6285,6 +6312,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-input-mask": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-3.0.6.tgz",
+      "integrity": "sha512-+5I18WKyG3eWIj7TVPWfK1VitI9mPpS9y6jE/BfmTCe+iL27NfBw/yzKRvCFp1DRBvlvvcsiZf05bub0YC1k8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -12434,6 +12470,20 @@
         "react": ">=0.0.0 <=99"
       }
     },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
@@ -12628,12 +12678,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",
@@ -13867,7 +13911,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14460,6 +14504,15 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -14675,21 +14728,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/src/auth/view/auth-demo/centered/centered-reset-password-view.tsx
+++ b/src/auth/view/auth-demo/centered/centered-reset-password-view.tsx
@@ -12,9 +12,9 @@ import { PasswordIcon } from 'src/assets/icons';
 
 import { Form, Field } from 'src/components/hook-form';
 
+import { forgotPassword } from '../../../context/jwt';
 import { FormHead } from '../../../components/form-head';
 import { FormReturnLink } from '../../../components/form-return-link';
-import { forgotPassword } from '../../../context/jwt';
 
 // ----------------------------------------------------------------------
 

--- a/src/auth/view/auth-demo/centered/centered-update-password-view.tsx
+++ b/src/auth/view/auth-demo/centered/centered-update-password-view.tsx
@@ -1,9 +1,8 @@
 import { z as zod } from 'zod';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useBoolean } from 'minimal-shared/hooks';
-import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useSearchParams } from 'src/routes/hooks';
 
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
@@ -11,15 +10,16 @@ import LoadingButton from '@mui/lab/LoadingButton';
 import InputAdornment from '@mui/material/InputAdornment';
 
 import { paths } from 'src/routes/paths';
+import { useSearchParams } from 'src/routes/hooks';
 
 import { SentIcon } from 'src/assets/icons';
 
 import { Iconify } from 'src/components/iconify';
 import { Form, Field } from 'src/components/hook-form';
 
+import { resetPassword } from '../../../context/jwt';
 import { FormHead } from '../../../components/form-head';
 import { FormReturnLink } from '../../../components/form-return-link';
-import { resetPassword } from '../../../context/jwt';
 
 // ----------------------------------------------------------------------
 
@@ -27,10 +27,6 @@ export type UpdatePasswordSchemaType = zod.infer<typeof UpdatePasswordSchema>;
 
 export const UpdatePasswordSchema = zod
   .object({
-    email: zod
-      .string()
-      .min(1, { message: 'Email é obrigatório!' })
-      .email({ message: 'Email deve ser válido!' }),
     password: zod
       .string()
       .min(1, { message: 'Senha é obrigatória!' })
@@ -55,7 +51,6 @@ export function CenteredUpdatePasswordView() {
   const [error, setError] = useState('');
 
   const defaultValues: UpdatePasswordSchemaType = {
-    email: emailFromQuery,
     password: '',
     confirmPassword: '',
   };
@@ -73,7 +68,7 @@ export function CenteredUpdatePasswordView() {
     try {
       setError('');
       await resetPassword({
-        email: data.email,
+        email: emailFromQuery,
         token,
         password: data.password,
         passwordConfirmation: data.confirmPassword,
@@ -87,12 +82,6 @@ export function CenteredUpdatePasswordView() {
 
   const renderForm = () => (
     <Box sx={{ gap: 3, display: 'flex', flexDirection: 'column' }}>
-      <Field.Text
-        name="email"
-        label="Email"
-        placeholder="example@gmail.com"
-        slotProps={{ inputLabel: { shrink: true } }}
-      />
 
       {error && (
         <Box


### PR DESCRIPTION
## Summary
- remove OTP & email inputs from update password form
- include email and token from URL when calling backend `/api/auth/reset-password`
- run lint fix to sort imports and update lockfile

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68432b9773e0832bb0facf3d5bd90f2b