### PR TITLE
Implement register route

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -78,7 +78,7 @@ export const endpoints = {
   auth: {
     me: '/api/auth/get-me', // Sua rota para buscar dados do usuário
     signIn: '/api/auth/login', // Endpoint do Laravel
-    signUp: '/api/auth/sign-up'
+    signUp: '/api/auth/register'
   },
   onboarding: '/api/onboarding',
   mail: { list: '/api/mail/list', details: '/api/mail/details', labels: '/api/mail/labels' },


### PR DESCRIPTION
## Summary
- implement register endpoint
- update JWT actions to call new `/api/auth/register`
- wire register page to API and store token

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: missing module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846f61994e4832bb7a5b147b02134dc