### PR TITLE
Fix onboarding redirect logic

### DIFF
--- a/src/auth/guard/onboarding-guard.tsx
+++ b/src/auth/guard/onboarding-guard.tsx
@@ -27,7 +27,7 @@ export function OnboardingGuard({ children }: OnboardingGuardProps) {
     }
 
     // If user is logged in but has no organization, force onboarding
-    if (user && !user.current_organization_id) {
+    if (user && user.current_organization_id == null) {
       if (pathname !== paths.onboarding.root) {
         router.replace(paths.onboarding.root);
       } else {
@@ -37,7 +37,7 @@ export function OnboardingGuard({ children }: OnboardingGuardProps) {
     }
 
     // If user has organization but tries to access onboarding, redirect to dashboard
-    if (user && user.current_organization_id && pathname.startsWith(paths.onboarding.root)) {
+    if (user && user.current_organization_id != null && pathname.startsWith(paths.onboarding.root)) {
       router.replace(paths.dashboard.root);
       return;
     }


### PR DESCRIPTION
## Summary
- only send users to onboarding when `current_organization_id` is null

## Testing
- `npm run lint` *(fails: cannot run due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6847049348c8832b90b128bc6786e089