### PR TITLE
Fix login session user data parsing

### DIFF
--- a/src/auth/context/jwt/auth-provider.tsx
+++ b/src/auth/context/jwt/auth-provider.tsx
@@ -34,9 +34,11 @@ export function AuthProvider({ children }: Props) {
         // Busca os dados do usuário usando o token na rota get-me
         const res = await axios.get(endpoints.auth.me);
 
-        const { user } = res.data;
+        // Alguns backends podem retornar os dados do usuário diretamente
+        // enquanto outros utilizam a chave "user". Suportamos ambos.
+        const userData = res.data.user ?? res.data;
 
-        setState({ user: { ...user, accessToken }, loading: false });
+        setState({ user: { ...userData, accessToken }, loading: false });
       } else {
         setState({ user: null, loading: false });
       }


### PR DESCRIPTION
## Summary
- handle different response shapes from `/auth/get-me` when loading user session

## Testing
- `npm run lint` *(fails: Cannot find package 'globals' because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847085ccc98832ba08c4bdc550a07c5